### PR TITLE
Organize argument parsing

### DIFF
--- a/argparse/argparse.go
+++ b/argparse/argparse.go
@@ -14,9 +14,6 @@ const (
 	AllTasks string = ":all"
 )
 
-// Types of task list
-type tlist int
-
 type taskHandler interface {
 	handleTasks(cmd *msg.Cmd, args []string) ([]string, error)
 	// TODO: Better options here? Write to a writer?

--- a/client/client.go
+++ b/client/client.go
@@ -116,7 +116,7 @@ func (c *Client) EstablishConnection() {
 	c.EnsureServerIsRunning()
 	socket := c.conf.ServerSocket()
 	if conn, err := net.Dial("unix", socket); err != nil {
-		c.err = errors.Wrap(err, "Failed to connect to socket"+socket)
+		c.err = errors.Wrap(err, "Failed to connect to socket "+socket)
 	} else {
 		c.conn = conn
 	}
@@ -215,7 +215,18 @@ func (c *Client) EnsureServerIsRunning() {
 	}
 }
 
+// Whether the server appears to be running.
+func (c *Client) ServerIsRunning() bool {
+	running, _ := server.IsRunning(c.conf)
+	return running
+}
+
 // Run the server in the foreground.
 func (c *Client) RunServer() {
 	c.err = server.Run(c.conf)
+}
+
+// Print a message for the user.
+func (c *Client) PrintMessage(message string) {
+	fmt.Fprintln(os.Stderr, message)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -32,23 +32,6 @@ func RegisterOperation(name string, operation ClientOperation) {
 	operations[name] = operation
 }
 
-type Client struct {
-	conf *config.Opts
-	conn net.Conn
-	err  error
-}
-
-// Read from the client's connection.
-func (cl *Client) Read(p []byte) (n int, err error) {
-	if cl.Failed() {
-		return 0, errors.Wrap(cl.err, "Cannot read from socket. Previous error")
-	}
-	if cl.conn == nil {
-		panic("Connection not yet established.")
-	}
-	return cl.conn.Read(p)
-}
-
 // Execute the appropriate action based on the configuration and the arguments.
 func Dispatch(conf *config.Opts, args []string) bool {
 	if len(args) == 0 {
@@ -71,6 +54,23 @@ func Dispatch(conf *config.Opts, args []string) bool {
 	} else {
 		return true
 	}
+}
+
+type Client struct {
+	conf *config.Opts
+	conn net.Conn
+	err  error
+}
+
+// Read from the client's connection.
+func (cl *Client) Read(p []byte) (n int, err error) {
+	if cl.Failed() {
+		return 0, errors.Wrap(cl.err, "Cannot read from socket. Previous error")
+	}
+	if cl.conn == nil {
+		panic("Connection not yet established.")
+	}
+	return cl.conn.Read(p)
 }
 
 func newClient(conf *config.Opts) *Client {
@@ -101,7 +101,7 @@ func (c *Client) Error() error {
 }
 
 // Send the command to the server, receive and print the response.
-func (c *Client) ServerRoundTrip(cmd msg.Cmd) {
+func (c *Client) SendReceivePrint(cmd msg.Cmd) {
 	c.EstablishConnection()
 	c.SendToServer(cmd)
 	resp := c.ReceiveFromServer()

--- a/command/abort/abort.go
+++ b/command/abort/abort.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type AbortOperation struct {
@@ -41,11 +42,8 @@ func (op AbortOperation) ServerExec(srv *server.Server, req *server.Request) err
 	return srv.Answer(req, resp)
 }
 
-func (op AbortOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Abort the current task",
-		LongDescription:  "Abort the current task",
-	}
+func (op AbortOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/abort/abort.go
+++ b/command/abort/abort.go
@@ -23,10 +23,7 @@ func (op AbortOperation) Parser() *argparse.Parser {
 }
 
 func (op AbortOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	cl.EstablishConnection()
-	cl.SendToServer(cmd)
-	resp := cl.ReceiveFromServer()
-	cl.PrintResponse(resp)
+	cl.SendReceivePrint(cmd)
 	return errors.Wrap(cl.Error(), "Failed to stop the current task")
 }
 

--- a/command/abort/abort.go
+++ b/command/abort/abort.go
@@ -17,14 +17,13 @@ func (op AbortOperation) Command() string {
 	return "abort"
 }
 
-func (op AbortOperation) ClientExec(cl *client.Client, args ...string) error {
-	argparse.WarnUnused(args)
-	stopCmd := msg.Cmd{
-		Op: op.Command(),
-	}
+func (op AbortOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithoutParams()
+}
 
+func (op AbortOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
 	cl.EstablishConnection()
-	cl.SendToServer(stopCmd)
+	cl.SendToServer(cmd)
 	resp := cl.ReceiveFromServer()
 	cl.PrintResponse(resp)
 	return errors.Wrap(cl.Error(), "Failed to stop the current task")
@@ -46,7 +45,6 @@ func (op AbortOperation) Help() command.Doc {
 	return command.Doc{
 		ShortDescription: "Abort the current task",
 		LongDescription:  "Abort the current task",
-		Arguments:        []string{},
 	}
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -14,7 +14,6 @@ var opNames = make(map[string]bool)
 type Doc struct {
 	ShortDescription string
 	LongDescription  string
-	Arguments        []string
 }
 
 type Operation interface {

--- a/command/command.go
+++ b/command/command.go
@@ -5,24 +5,17 @@ import (
 	"fmt"
 	"github.com/fgahr/tilo/client"
 	"github.com/fgahr/tilo/server"
+	"io"
 	"os"
 )
 
 var opNames = make(map[string]bool)
-
-// TODO: Define proper structure
-type Doc struct {
-	ShortDescription string
-	LongDescription  string
-}
 
 type Operation interface {
 	client.ClientOperation
 	server.ServerOperation
 	// The command identifier
 	Command() string
-	// Documentation for this operation
-	Help() Doc
 }
 
 func RegisterOperation(op Operation) {
@@ -34,12 +27,12 @@ func RegisterOperation(op Operation) {
 	server.RegisterOperation(op.Command(), op)
 }
 
-func PrintSingleOperationHelp(op Operation) {
-	// TODO
-	fmt.Fprintf(os.Stderr, "Currently no help message for operation '%s'\n", op.Command())
+func PrintSingleOperationHelp(op Operation, w io.Writer) {
+	// TODO: Add actual help message
+	fmt.Fprintf(w, "Currently no help message for operation '%s'\n", op.Command())
 }
 
 func PrintAllOperationsHelp() {
-	// TODO
+	// TODO: Use parser description
 	fmt.Fprintln(os.Stderr, "Currently no help message exists.")
 }

--- a/command/current/current.go
+++ b/command/current/current.go
@@ -23,10 +23,7 @@ func (op CurrentOperation) Parser() *argparse.Parser {
 }
 
 func (op CurrentOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	cl.EstablishConnection()
-	cl.SendToServer(cmd)
-	resp := cl.ReceiveFromServer()
-	cl.PrintResponse(resp)
+	cl.SendReceivePrint(cmd)
 	return errors.Wrap(cl.Error(), "Failed to determine the current task")
 }
 

--- a/command/current/current.go
+++ b/command/current/current.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type CurrentOperation struct {
@@ -40,11 +41,8 @@ func (op CurrentOperation) ServerExec(srv *server.Server, req *server.Request) e
 	return srv.Answer(req, resp)
 }
 
-func (op CurrentOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Print the currently running task",
-		LongDescription:  "Print the currently running task",
-	}
+func (op CurrentOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/current/current.go
+++ b/command/current/current.go
@@ -1,6 +1,7 @@
 package current
 
 import (
+	"github.com/fgahr/tilo/argparse"
 	"github.com/fgahr/tilo/client"
 	"github.com/fgahr/tilo/command"
 	"github.com/fgahr/tilo/msg"
@@ -16,13 +17,13 @@ func (op CurrentOperation) Command() string {
 	return "current"
 }
 
-func (op CurrentOperation) ClientExec(cl *client.Client, args ...string) error {
-	currentCmd := msg.Cmd{
-		Op: op.Command(),
-	}
+func (op CurrentOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithoutParams()
+}
 
+func (op CurrentOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
 	cl.EstablishConnection()
-	cl.SendToServer(currentCmd)
+	cl.SendToServer(cmd)
 	resp := cl.ReceiveFromServer()
 	cl.PrintResponse(resp)
 	return errors.Wrap(cl.Error(), "Failed to determine the current task")
@@ -40,11 +41,9 @@ func (op CurrentOperation) ServerExec(srv *server.Server, req *server.Request) e
 }
 
 func (op CurrentOperation) Help() command.Doc {
-	// TODO: Improve, figure out what's required
 	return command.Doc{
 		ShortDescription: "Print the currently running task",
 		LongDescription:  "Print the currently running task",
-		Arguments:        []string{},
 	}
 }
 

--- a/command/listen/listen.go
+++ b/command/listen/listen.go
@@ -49,11 +49,8 @@ func (op ListenOperation) ServerExec(srv *server.Server, req *server.Request) er
 	return srv.Answer(req, resp)
 }
 
-func (op ListenOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Listen for notifications",
-		LongDescription:  "Listen for notifications",
-	}
+func (op ListenOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/listen/listen.go
+++ b/command/listen/listen.go
@@ -19,12 +19,13 @@ func (op ListenOperation) Command() string {
 	return "listen"
 }
 
-func (op ListenOperation) ClientExec(cl *client.Client, args ...string) error {
-	argparse.WarnUnused(args)
-	listenCmd := msg.Cmd{Op: "listen"}
+func (op ListenOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithoutParams()
+}
 
+func (op ListenOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
 	cl.EstablishConnection()
-	cl.SendToServer(listenCmd)
+	cl.SendToServer(cmd)
 	resp := cl.ReceiveFromServer()
 	if resp.Err() != nil {
 		return resp.Err()
@@ -52,7 +53,6 @@ func (op ListenOperation) Help() command.Doc {
 	return command.Doc{
 		ShortDescription: "Listen for notifications",
 		LongDescription:  "Listen for notifications",
-		Arguments:        []string{},
 	}
 }
 

--- a/command/ping/ping.go
+++ b/command/ping/ping.go
@@ -25,6 +25,7 @@ func (op PingOperation) Parser() *argparse.Parser {
 }
 
 func (op PingOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
+	cl.EstablishConnection()
 	before := time.Now()
 	if _, err := fmt.Fprintln(os.Stderr, "Sending ping to server"); err != nil {
 		return err

--- a/command/ping/ping.go
+++ b/command/ping/ping.go
@@ -19,14 +19,16 @@ func (op PingOperation) Command() string {
 	return "ping"
 }
 
-func (op PingOperation) ClientExec(cl *client.Client, args ...string) error {
-	argparse.WarnUnused(args)
-	pingCmd := msg.Cmd{Op: op.Command()}
+func (op PingOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithoutParams()
+}
+
+func (op PingOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
 	before := time.Now()
 	if _, err := fmt.Fprintln(os.Stderr, "Sending ping to server"); err != nil {
 		return err
 	}
-	cl.SendToServer(pingCmd)
+	cl.SendToServer(cmd)
 	cl.ReceiveFromServer() // Ignoring response
 	after := time.Now()
 	if cl.Failed() {

--- a/command/ping/ping.go
+++ b/command/ping/ping.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/command"
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
+	"io"
 	"os"
 	"time"
 )
@@ -46,11 +47,8 @@ func (op PingOperation) ServerExec(srv *server.Server, req *server.Request) erro
 	return srv.Answer(req, resp)
 }
 
-func (op PingOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Check whether the server is running",
-		LongDescription:  "Check whether the server is running",
-	}
+func (op PingOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/query/query.go
+++ b/command/query/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type QueryOperation struct {
@@ -57,12 +58,8 @@ Outer:
 	return srv.Answer(req, resp)
 }
 
-func (op QueryOperation) Help() command.Doc {
-	// TODO: Improve, figure out what's required
-	return command.Doc{
-		ShortDescription: "Query the backend",
-		LongDescription:  "Query the backend",
-	}
+func (op QueryOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/query/query.go
+++ b/command/query/query.go
@@ -33,11 +33,7 @@ func (op QueryOperation) Parser() *argparse.Parser {
 }
 
 func (op QueryOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	// TODO: Abstract this pattern away
-	cl.EstablishConnection()
-	cl.SendToServer(cmd)
-	resp := cl.ReceiveFromServer()
-	cl.PrintResponse(resp)
+	cl.SendReceivePrint(cmd)
 	return errors.Wrap(cl.Error(), "Failed to query the server")
 }
 

--- a/command/shutdown/shutdown.go
+++ b/command/shutdown/shutdown.go
@@ -23,10 +23,7 @@ func (op ShutdownOperation) Parser() *argparse.Parser {
 }
 
 func (op ShutdownOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	cl.EstablishConnection()
-	cl.SendToServer(cmd)
-	resp := cl.ReceiveFromServer()
-	cl.PrintResponse(resp)
+	cl.SendReceivePrint(cmd)
 	return errors.Wrapf(cl.Error(), "Failed to initiate server shutdown")
 }
 

--- a/command/shutdown/shutdown.go
+++ b/command/shutdown/shutdown.go
@@ -1,6 +1,7 @@
 package shutdown
 
 import (
+	"github.com/fgahr/tilo/argparse"
 	"github.com/fgahr/tilo/client"
 	"github.com/fgahr/tilo/command"
 	"github.com/fgahr/tilo/msg"
@@ -16,13 +17,13 @@ func (op ShutdownOperation) Command() string {
 	return "shutdown"
 }
 
-func (op ShutdownOperation) ClientExec(cl *client.Client, args ...string) error {
-	shutdownCmd := msg.Cmd{
-		Op: op.Command(),
-	}
+func (op ShutdownOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithoutParams()
+}
 
+func (op ShutdownOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
 	cl.EstablishConnection()
-	cl.SendToServer(shutdownCmd)
+	cl.SendToServer(cmd)
 	resp := cl.ReceiveFromServer()
 	cl.PrintResponse(resp)
 	return errors.Wrapf(cl.Error(), "Failed to initiate server shutdown")
@@ -44,11 +45,9 @@ func (op ShutdownOperation) ServerExec(srv *server.Server, req *server.Request) 
 }
 
 func (op ShutdownOperation) Help() command.Doc {
-	// TODO: Improve, figure out what's required
 	return command.Doc{
 		ShortDescription: "Request server shutdown",
 		LongDescription:  "Request server shutdown",
-		Arguments:        []string{""},
 	}
 }
 

--- a/command/shutdown/shutdown.go
+++ b/command/shutdown/shutdown.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type ShutdownOperation struct {
@@ -44,11 +45,8 @@ func (op ShutdownOperation) ServerExec(srv *server.Server, req *server.Request) 
 	return srv.Answer(req, resp)
 }
 
-func (op ShutdownOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Request server shutdown",
-		LongDescription:  "Request server shutdown",
-	}
+func (op ShutdownOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/shutdown/shutdown.go
+++ b/command/shutdown/shutdown.go
@@ -23,7 +23,11 @@ func (op ShutdownOperation) Parser() *argparse.Parser {
 }
 
 func (op ShutdownOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	cl.SendReceivePrint(cmd)
+	if cl.ServerIsRunning() {
+		cl.SendReceivePrint(cmd)
+	} else {
+		cl.PrintMessage("Server appears to be down. Nothing to do")
+	}
 	return errors.Wrapf(cl.Error(), "Failed to initiate server shutdown")
 }
 

--- a/command/srvcmd/srvcmd.go
+++ b/command/srvcmd/srvcmd.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
+	RUN   = "run"
 	START = "start"
-	STOP  = "stop"
 )
 
 type CommandHandler struct {
@@ -33,9 +33,9 @@ func (h *CommandHandler) HandleParams(_ *msg.Cmd, params []string) ([]string, er
 
 func isKnownCommand(str string) bool {
 	switch str {
-	case START:
+	case RUN:
 		return true
-	case STOP:
+	case START:
 		return true
 	default:
 		return false
@@ -58,7 +58,7 @@ func (op ServerOperation) ClientExec(cl *client.Client, _ msg.Cmd) error {
 	switch op.ch.command {
 	case START:
 		cl.EnsureServerIsRunning()
-	case STOP:
+	case RUN:
 		cl.RunServer()
 	}
 	return cl.Error()

--- a/command/srvcmd/srvcmd.go
+++ b/command/srvcmd/srvcmd.go
@@ -9,22 +9,32 @@ import (
 	"github.com/pkg/errors"
 )
 
+type CommandHandler struct {
+	command string
+}
+
+func (h *CommandHandler) HandleParams(_ *msg.Cmd, params []string) ([]string, error) {
+	if len(params) == 0 {
+		return params, errors.New("Require a command but none was given")
+	}
+	h.command = params[0]
+	return params[1:], nil
+}
+
 type ServerOperation struct {
-	// No state required
+	ch *CommandHandler
 }
 
 func (op ServerOperation) Command() string {
 	return "server"
 }
 
-func (op ServerOperation) ClientExec(cl *client.Client, args ...string) error {
-	if len(args) == 0 {
-		command.PrintSingleOperationHelp(op)
-		return nil
-	}
-	argparse.WarnUnused(args[1:])
+func (op ServerOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithParamHandler(op.ch)
+}
 
-	switch args[0] {
+func (op ServerOperation) ClientExec(cl *client.Client, _ msg.Cmd) error {
+	switch op.ch.command {
 	case "start":
 		cl.EnsureServerIsRunning()
 	case "run":
@@ -46,10 +56,9 @@ func (op ServerOperation) Help() command.Doc {
 	return command.Doc{
 		ShortDescription: "Run in server mode",
 		LongDescription:  "Run in server mode",
-		Arguments:        []string{"start|run"},
 	}
 }
 
 func init() {
-	command.RegisterOperation(ServerOperation{})
+	command.RegisterOperation(ServerOperation{new(CommandHandler)})
 }

--- a/command/start/start.go
+++ b/command/start/start.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type StartOperation struct {
@@ -45,11 +46,8 @@ func (op StartOperation) ServerExec(srv *server.Server, req *server.Request) err
 	return srv.Answer(req, resp)
 }
 
-func (op StartOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Start a task",
-		LongDescription:  "Start a task",
-	}
+func (op StartOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/command/start/start.go
+++ b/command/start/start.go
@@ -23,10 +23,7 @@ func (op StartOperation) Parser() *argparse.Parser {
 }
 
 func (op StartOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	cl.EstablishConnection()
-	cl.SendToServer(cmd)
-	resp := cl.ReceiveFromServer()
-	cl.PrintResponse(resp)
+	cl.SendReceivePrint(cmd)
 	return errors.Wrapf(cl.Error(), "Failed to start task '%s'", cmd.Tasks[0])
 }
 

--- a/command/stop/stop.go
+++ b/command/stop/stop.go
@@ -23,10 +23,7 @@ func (op StopOperation) Parser() *argparse.Parser {
 }
 
 func (op StopOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
-	cl.EstablishConnection()
-	cl.SendToServer(cmd)
-	resp := cl.ReceiveFromServer()
-	cl.PrintResponse(resp)
+	cl.SendReceivePrint(cmd)
 	return errors.Wrap(cl.Error(), "Failed to stop the current task")
 }
 

--- a/command/stop/stop.go
+++ b/command/stop/stop.go
@@ -17,14 +17,13 @@ func (op StopOperation) Command() string {
 	return "stop"
 }
 
-func (op StopOperation) ClientExec(cl *client.Client, args ...string) error {
-	argparse.WarnUnused(args)
-	stopCmd := msg.Cmd{
-		Op: op.Command(),
-	}
+func (op StopOperation) Parser() *argparse.Parser {
+	return argparse.CommandParser(op.Command()).WithoutTask().WithoutParams()
+}
 
+func (op StopOperation) ClientExec(cl *client.Client, cmd msg.Cmd) error {
 	cl.EstablishConnection()
-	cl.SendToServer(stopCmd)
+	cl.SendToServer(cmd)
 	resp := cl.ReceiveFromServer()
 	cl.PrintResponse(resp)
 	return errors.Wrap(cl.Error(), "Failed to stop the current task")
@@ -49,7 +48,6 @@ func (op StopOperation) Help() command.Doc {
 	return command.Doc{
 		ShortDescription: "Stop the current task",
 		LongDescription:  "Stop the current task",
-		Arguments:        []string{},
 	}
 }
 

--- a/command/stop/stop.go
+++ b/command/stop/stop.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fgahr/tilo/msg"
 	"github.com/fgahr/tilo/server"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type StopOperation struct {
@@ -44,11 +45,8 @@ func (op StopOperation) ServerExec(srv *server.Server, req *server.Request) erro
 	return srv.Answer(req, resp)
 }
 
-func (op StopOperation) Help() command.Doc {
-	return command.Doc{
-		ShortDescription: "Stop the current task",
-		LongDescription:  "Stop the current task",
-	}
+func (op StopOperation) PrintUsage(w io.Writer) {
+	command.PrintSingleOperationHelp(op, w)
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -38,8 +38,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := client.Dispatch(conf, args); err != nil {
-		// TODO: Consider printing without timestamp
-		log.Fatal(err)
+	if client.Dispatch(conf, args) {
+		os.Exit(0)
+	} else {
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Operations must now feature an accessible command line argument parser. Consequently, argument parsing is no longer done within the client-side operations themselves.

It is still possible to ignore all pre-defined argument parsing to arbitrary degrees, see the `server` and `query` operations for examples.